### PR TITLE
fix: implement server-side auth API calls in signin/signup pages

### DIFF
--- a/DevOps-Project-39/wanderlust-3tier-project/frontend/src/pages/signin-page.tsx
+++ b/DevOps-Project-39/wanderlust-3tier-project/frontend/src/pages/signin-page.tsx
@@ -19,16 +19,28 @@ function signin() {
   } = useForm<TSignInSchema>({ resolver: zodResolver(signInSchema) });
 
   const onSubmit = async (data: FieldValues) => {
-    if (data.email === 'abc@gamil.com') {
-      toast.error('Submitting form is failed');
-      return;
+    try {
+      const apiUrl = import.meta.env.VITE_API_PATH ?? 'http://localhost:5000';
+      const response = await fetch(`${apiUrl}/api/auth/email-password/signin`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          email: data.email,
+          password: data.password,
+        }),
+      });
+      const result = await response.json();
+      if (!response.ok) {
+        toast.error(result.message ?? 'Sign in failed. Please check your credentials.');
+        return;
+      }
+      toast.success(result.message ?? 'Signed in successfully!');
+      reset();
+      navigate('/');
+    } catch {
+      toast.error('Unable to connect to the server. Please try again later.');
     }
-
-    // TODO: Server-side validation
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
-    reset();
-    navigate('/');
   };
 
   return (

--- a/DevOps-Project-39/wanderlust-3tier-project/frontend/src/pages/signup-page.tsx
+++ b/DevOps-Project-39/wanderlust-3tier-project/frontend/src/pages/signup-page.tsx
@@ -19,16 +19,29 @@ function signin() {
   } = useForm<TSignUpSchema>({ resolver: zodResolver(signUpSchema) });
 
   const onSubmit = async (data: FieldValues) => {
-    if (data.email === 'abc@gamil.com') {
-      toast.error('Submitting form is failed');
-      return;
+    try {
+      const apiUrl = import.meta.env.VITE_API_PATH ?? 'http://localhost:5000';
+      const response = await fetch(`${apiUrl}/api/auth/email-password/signup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          name: data.username,
+          email: data.email,
+          password: data.password,
+        }),
+      });
+      const result = await response.json();
+      if (!response.ok) {
+        toast.error(result.message ?? 'Sign up failed. Please try again.');
+        return;
+      }
+      toast.success(result.message ?? 'Account created successfully!');
+      reset();
+      navigate('/');
+    } catch {
+      toast.error('Unable to connect to the server. Please try again later.');
     }
-
-    // TODO: Server-side validation
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
-    reset();
-    navigate('/');
   };
 
   return (

--- a/DevOps-Project-40/Devops-Mega-Project-Jenkins-ArgoCD-EKS/frontend/src/pages/signin-page.tsx
+++ b/DevOps-Project-40/Devops-Mega-Project-Jenkins-ArgoCD-EKS/frontend/src/pages/signin-page.tsx
@@ -19,16 +19,28 @@ function signin() {
   } = useForm<TSignInSchema>({ resolver: zodResolver(signInSchema) });
 
   const onSubmit = async (data: FieldValues) => {
-    if (data.email === 'abc@gamil.com') {
-      toast.error('Submitting form is failed');
-      return;
+    try {
+      const apiUrl = import.meta.env.VITE_API_PATH ?? 'http://localhost:5000';
+      const response = await fetch(`${apiUrl}/api/auth/email-password/signin`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          email: data.email,
+          password: data.password,
+        }),
+      });
+      const result = await response.json();
+      if (!response.ok) {
+        toast.error(result.message ?? 'Sign in failed. Please check your credentials.');
+        return;
+      }
+      toast.success(result.message ?? 'Signed in successfully!');
+      reset();
+      navigate('/');
+    } catch {
+      toast.error('Unable to connect to the server. Please try again later.');
     }
-
-    // TODO: Server-side validation
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
-    reset();
-    navigate('/');
   };
 
   return (

--- a/DevOps-Project-40/Devops-Mega-Project-Jenkins-ArgoCD-EKS/frontend/src/pages/signup-page.tsx
+++ b/DevOps-Project-40/Devops-Mega-Project-Jenkins-ArgoCD-EKS/frontend/src/pages/signup-page.tsx
@@ -19,16 +19,29 @@ function signin() {
   } = useForm<TSignUpSchema>({ resolver: zodResolver(signUpSchema) });
 
   const onSubmit = async (data: FieldValues) => {
-    if (data.email === 'abc@gamil.com') {
-      toast.error('Submitting form is failed');
-      return;
+    try {
+      const apiUrl = import.meta.env.VITE_API_PATH ?? 'http://localhost:5000';
+      const response = await fetch(`${apiUrl}/api/auth/email-password/signup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          name: data.username,
+          email: data.email,
+          password: data.password,
+        }),
+      });
+      const result = await response.json();
+      if (!response.ok) {
+        toast.error(result.message ?? 'Sign up failed. Please try again.');
+        return;
+      }
+      toast.success(result.message ?? 'Account created successfully!');
+      reset();
+      navigate('/');
+    } catch {
+      toast.error('Unable to connect to the server. Please try again later.');
     }
-
-    // TODO: Server-side validation
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-
-    reset();
-    navigate('/');
   };
 
   return (


### PR DESCRIPTION
## Summary

- Replace the client-side-only stub (fake 1s timeout + hardcoded `abc@gamil.com` check) with real `fetch` calls to the backend auth endpoints in both **DevOps-Project-39** and **DevOps-Project-40**
- Map frontend `username` field to the backend `name` field (fixes field name mismatch)
- Show backend error messages via toast on failure; navigate home only on success
- Use the existing `VITE_API_PATH` env var — consistent with every other page (`home-page`, `add-blog`, `blog-feed`, etc.)

## Changes

| File | Change |
|------|--------|
| `DevOps-Project-39/.../signup-page.tsx` | POST to `/api/auth/email-password/signup` |
| `DevOps-Project-39/.../signin-page.tsx` | POST to `/api/auth/email-password/signin` |
| `DevOps-Project-40/.../signup-page.tsx` | POST to `/api/auth/email-password/signup` |
| `DevOps-Project-40/.../signin-page.tsx` | POST to `/api/auth/email-password/signin` |

## Type of change
- [x] Bug fix (resolves `TODO: Server-side validation` in both projects)

## Checklist
- [x] Tested locally against the Express backend
- [x] No hardcoded credentials or sensitive data
- [x] Follows existing code style and env var conventions
- [x] PR is focused and single-purpose

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sign-in and sign-up now connect to the server for real authentication instead of using placeholder behavior.
  * Users receive success and error toast messages during account access.

* **Bug Fixes**
  * Improved handling of connection failures with clearer feedback.
  * Forms now only reset and redirect after a successful request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->