### PR TITLE
Upgrade Maven compiler source and target to 1.8

### DIFF
--- a/DevOps-Project-05/hello-world/pom.xml
+++ b/DevOps-Project-05/hello-world/pom.xml
@@ -34,8 +34,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
                     <plugin>


### PR DESCRIPTION
Hi,

While testing DevOps-Project-05 with the latest Jenkins Docker image and newer JDK versions, I noticed that the Maven build fails because the project is still configured with Java 7 source/target compatibility.

Error observed:

"Source option 7 is no longer supported. Use 8 or later."

Modern JDK versions no longer support compiling with source/target 1.7, so I have updated the Maven compiler configuration from Java 1.7 to Java 1.8.

Changes:
- Updated maven.compiler.source from 1.7 → 1.8
- Updated maven.compiler.target from 1.7 → 1.8

This keeps the project compatible with newer Jenkins + Docker environments while maintaining backward compatibility.

Tested with:
- Jenkins running in Docker
- Maven build: mvn clean install
- OpenJDK newer runtime

Build passes successfully after this change.

Thanks for maintaining this helpful DevOps learning repository!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project to compile with Java 8 instead of Java 7.
  * This helps keep the app aligned with newer Java environments and builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->